### PR TITLE
Blank topic cleanup

### DIFF
--- a/speakers/Grant-Fritchey.json
+++ b/speakers/Grant-Fritchey.json
@@ -1,6 +1,6 @@
 {
   "name": "Grant Fritchey",
-  "topics": "Performance tuning, execution plans, DevOps, automation, deployment,",
+  "topics": "Performance tuning, execution plans, DevOps, automation, deployment",
   "regions": "Europe, Middle East, Africa, South Asia, South East Asia, East Asia, Oceania, North America, South America",
   "sessionize": "https://sessionize.com/GrantFritchey/",
   "language": "English"

--- a/speakers/Indira-Bandari.json
+++ b/speakers/Indira-Bandari.json
@@ -1,6 +1,6 @@
 {
   "name": "Indira Bandari",
-  "topics": "Power BI, Azure SQL, Azure ML, Azure Synapse, ",
+  "topics": "Power BI, Azure SQL, Azure ML, Azure Synapse",
   "regions": "Virtual, Oceania",
   "sessionize": "https://sessionize.com/indira-bandari/",
   "language": "English, Telugu"


### PR DESCRIPTION
Trailing commas in the topics list create "blank" topic boxes on the web page.

Yes, some day I will fix the display code for the web page, but this is lower-hanging fruit right now. :)